### PR TITLE
Added "contentType" parameter to "translate" API method to translate HTML texts

### DIFF
--- a/src/MatthiasNoback/MicrosoftTranslator/ApiCall/Translate.php
+++ b/src/MatthiasNoback/MicrosoftTranslator/ApiCall/Translate.php
@@ -4,12 +4,16 @@ namespace MatthiasNoback\MicrosoftTranslator\ApiCall;
 
 class Translate extends AbstractMicrosoftTranslatorApiCall
 {
+    const CONTENT_TYPE_TEXT = 'text/plain';
+    const CONTENT_TYPE_HTML = 'text/html';
+
     private $text;
     private $to;
     private $from;
+    private $contentType;
     private $category;
 
-    public function __construct($text, $to, $from = null, $category = null)
+    public function __construct($text, $to, $from = null, $contentType = self::CONTENT_TYPE_TEXT, $category = null)
     {
         if (strlen($text) > self::MAXIMUM_LENGTH_OF_TEXT) {
             throw new \InvalidArgumentException(sprintf('Text may not be longer than %d characters', self::MAXIMUM_LENGTH_OF_TEXT));
@@ -18,6 +22,7 @@ class Translate extends AbstractMicrosoftTranslatorApiCall
         $this->text = $text;
         $this->to = $to;
         $this->from = $from;
+        $this->contentType = $contentType;
         $this->category = $category;
     }
 
@@ -41,8 +46,8 @@ class Translate extends AbstractMicrosoftTranslatorApiCall
             'text'        => $this->text,
             'from'        => $this->from,
             'to'          => $this->to,
+            'contentType' => $this->contentType,
             'category'    => $this->category,
-            'contentType' => 'text/plain',
         );
     }
 

--- a/src/MatthiasNoback/MicrosoftTranslator/MicrosoftTranslator.php
+++ b/src/MatthiasNoback/MicrosoftTranslator/MicrosoftTranslator.php
@@ -2,10 +2,10 @@
 
 namespace MatthiasNoback\MicrosoftTranslator;
 
+use Buzz\Browser;
+use MatthiasNoback\Exception\RequestFailedException;
 use MatthiasNoback\MicrosoftOAuth\AccessTokenProviderInterface;
 use MatthiasNoback\MicrosoftTranslator\ApiCall;
-use MatthiasNoback\Exception\RequestFailedException;
-use Buzz\Browser;
 
 class MicrosoftTranslator
 {
@@ -29,20 +29,27 @@ class MicrosoftTranslator
     }
 
     /**
-     * Translates a given text to the given language
+     * Translates a given text or html to the given language
      *
-     * The language of the given text is optional, and will be auto-detected
+     * The language of the given text or html is optional, and will be auto-detected
      * The category will default to "general"
      *
      * @param string $text
      * @param string $to
      * @param string|null $from
+     * @param string $contentType
      * @param string|null $category
      * @return string
      */
-    public function translate($text, $to, $from = null, $category = null)
+    public function translate(
+        $text,
+        $to,
+        $from = null,
+        $contentType = ApiCall\Translate::CONTENT_TYPE_TEXT,
+        $category = null
+    )
     {
-        $apiCall = new ApiCall\Translate($text, $to, $from, $category);
+        $apiCall = new ApiCall\Translate($text, $to, $from, $contentType, $category);
 
         return $this->call($apiCall);
     }

--- a/tests/MatthiasNoback/MicrosoftTranslator/ApiCall/TranslateTest.php
+++ b/tests/MatthiasNoback/MicrosoftTranslator/ApiCall/TranslateTest.php
@@ -29,15 +29,16 @@ class TranslateTest extends \PHPUnit_Framework_TestCase
         $text = 'text';
         $from = 'from';
         $to = 'to';
+        $contentType = 'contentType';
         $category = 'category';
 
-        $apiCall = new ApiCall\Translate($text, $to, $from, $category);
+        $apiCall = new ApiCall\Translate($text, $to, $from, $contentType, $category);
         $this->assertEquals(array(
             'text'        => $text,
             'from'        => $from,
             'to'          => $to,
+            'contentType' => $contentType,
             'category'    => $category,
-            'contentType' => 'text/plain',
         ), $apiCall->getQueryParameters());
     }
 

--- a/tests/MatthiasNoback/MicrosoftTranslator/MicrosoftTranslatorFunctionalTest.php
+++ b/tests/MatthiasNoback/MicrosoftTranslator/MicrosoftTranslatorFunctionalTest.php
@@ -4,12 +4,13 @@ namespace MatthiasNoback\Tests\MicrosoftTranslator;
 
 use Buzz\Browser;
 use Buzz\Client\Curl;
-use MatthiasNoback\MicrosoftOAuth\AccessTokenProvider;
-use MatthiasNoback\MicrosoftTranslator\ApiCall\Response\TranslationMatch;
-use MatthiasNoback\MicrosoftTranslator\MicrosoftTranslator;
-use MatthiasNoback\MicrosoftOAuth\AccessTokenCache;
 use Doctrine\Common\Cache\ArrayCache;
 use MatthiasNoback\Buzz\Client\CachedClient;
+use MatthiasNoback\MicrosoftOAuth\AccessTokenCache;
+use MatthiasNoback\MicrosoftOAuth\AccessTokenProvider;
+use MatthiasNoback\MicrosoftTranslator\ApiCall\Response\TranslationMatch;
+use MatthiasNoback\MicrosoftTranslator\ApiCall\Translate;
+use MatthiasNoback\MicrosoftTranslator\MicrosoftTranslator;
 
 class MicrosoftTranslatorFunctionalTest extends \PHPUnit_Framework_TestCase
 {
@@ -45,6 +46,26 @@ class MicrosoftTranslatorFunctionalTest extends \PHPUnit_Framework_TestCase
         $translated = $this->translator->translate('This is a test', 'nl', 'en');
 
         $this->assertSame('Dit is een test', $translated);
+
+        $translated = $this->translator->translate(
+            '<p class="name">This is a test</p>',
+            'nl',
+            'en',
+            Translate::CONTENT_TYPE_HTML,
+            null
+        );
+
+        $this->assertSame('<p class="name">Dit is een test</p>', $translated);
+
+        $translated = $this->translator->translate(
+            '<p>This is a test.<span class="notranslate">This is a test.</span></p>',
+            'nl',
+            'en',
+            Translate::CONTENT_TYPE_HTML,
+            null
+        );
+
+        $this->assertSame('<p>Dit is een test.<span class="notranslate">This is a test.</span></p>', $translated);
     }
 
     public function testTranslateArray()
@@ -58,7 +79,7 @@ class MicrosoftTranslatorFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array(
             'Dit is een test',
             'Mijn naam is Matthias',
-            'U bent naïef!',
+            'Je bent naïef!',
         ), $translatedTexts);
     }
 


### PR DESCRIPTION
+ fixed one test, because "You are naïve!" is being translated as "Je bent naïef!" now apparently.

I'm not sure about your tests code style, I added 2 asserts into testTranslate method, because I didn't know if you'd rather create separated test methods.

Hopefully it's done correctly :)