### PR TITLE
Added Azure Token Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,28 @@ Then using the Composer binary:
 
 This library uses the Buzz browser to make calls to the [Microsoft Translator V2 API](http://msdn.microsoft.com/en-us/library/ff512419.aspx).
 
+You need to [obtain a Microsoft Azure Cognitive Services subscription Key](http://docs.microsofttranslator.com/text-translate.html). This can be used to instantiate the ``AzureTokenProvider``:
+
+```php
+<?php
+
+use Buzz\Browser;
+use MatthiasNoback\MicrosoftOAuth\AzureTokenProvider;
+use MatthiasNoback\MicrosoftTranslator\MicrosoftTranslator;
+
+$browser = new Browser();
+
+$azureKey = '[YOUR-AZURE-SUBSCRIPTION-KEY]';
+
+$accessTokenProvider = new AzureTokenProvider($browser, $azureKey);
+
+$translator = new MicrosoftTranslator($browser, $accessTokenProvider);
+```
+
+## Azure DataMarket token usage [deprecated]
+
 You need to register your application at the [Azure DataMarket](https://datamarket.azure.com/developer/applications) and
-thereby retrieve a "client id" and a "client secret". These kan be used to instantiate the ``AccessTokenProvider`` on which
+thereby retrieve a "client id" and a "client secret". These can be used to instantiate the ``AccessTokenProvider`` (deprecated) on which
 the ``MicrosoftTranslator`` depends:
 
 ```php
@@ -42,6 +62,7 @@ $accessTokenProvider = new AccessTokenProvider($browser, $clientId, $clientSecre
 
 $translator = new MicrosoftTranslator($browser, $accessTokenProvider);
 ```
+
 
 ### Optional: enable the access token cache
 

--- a/src/MatthiasNoback/MicrosoftOAuth/AzureTokenProvider.php
+++ b/src/MatthiasNoback/MicrosoftOAuth/AzureTokenProvider.php
@@ -63,7 +63,8 @@ class AzureTokenProvider implements AccessTokenProviderInterface
     {
         try {
             $response = $this->browser->post(
-                self::AUTH_URL . "?Subscription-Key=" . urlencode($this->azureKey)
+                self::AUTH_URL . "?Subscription-Key=" . urlencode($this->azureKey),
+                ['Content-Length' => 0]
             );
         }
         catch (\Exception $previous) {

--- a/src/MatthiasNoback/MicrosoftOAuth/AzureTokenProvider.php
+++ b/src/MatthiasNoback/MicrosoftOAuth/AzureTokenProvider.php
@@ -64,7 +64,7 @@ class AzureTokenProvider implements AccessTokenProviderInterface
         try {
             $response = $this->browser->post(
                 self::AUTH_URL . "?Subscription-Key=" . urlencode($this->azureKey),
-                ['Content-Length' => 0]
+                array('Content-Length' => 0)
             );
         }
         catch (\Exception $previous) {

--- a/src/MatthiasNoback/MicrosoftOAuth/AzureTokenProvider.php
+++ b/src/MatthiasNoback/MicrosoftOAuth/AzureTokenProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace MatthiasNoback\MicrosoftOAuth;
+
+use Buzz\Browser;
+use MatthiasNoback\Exception\RequestFailedException;
+use MatthiasNoback\Exception\InvalidResponseException;
+
+class AzureTokenProvider implements AccessTokenProviderInterface
+{
+    const AUTH_URL = 'https://api.cognitive.microsoft.com/sts/v1.0/issueToken';
+
+    /**
+     * @var \Buzz\Browser
+     */
+    private $browser;
+
+    /**
+     * @var string The client id of your application
+     */
+    private $azureKey;
+
+    /**
+     * @var AccessTokenCacheInterface|null
+     */
+    private $accessTokenCache;
+
+    /**
+     * The AccessTokenProvider requires a Buzz browser instance, and both a client id
+     * and a client secret. You can obtain these by registering your application
+     * at https://datamarket.azure.com/developer/applications
+     *
+     * @param \Buzz\Browser $browser The browser to use for fetching access tokens
+     * @param string $azureKey       The azure key for Translator service
+     */
+    public function __construct(Browser $browser, $azureKey)
+    {
+        $this->browser = $browser;
+        $this->azureKey = $azureKey;
+    }
+
+    public function setCache(AccessTokenCacheInterface $accessTokenCache)
+    {
+        $this->accessTokenCache = $accessTokenCache;
+    }
+
+    public function getAccessToken($scope, $grantType)
+    {
+        if ($this->accessTokenCache !== null && $this->accessTokenCache->has($scope, $grantType)) {
+            return $this->accessTokenCache->get($scope, $grantType);
+        }
+
+        $accessToken = $this->authorize($scope, $grantType);
+
+        if ($this->accessTokenCache !== null) {
+            $this->accessTokenCache->set($scope, $grantType, $accessToken);
+        }
+
+        return $accessToken;
+    }
+
+    private function authorize($scope, $grantType)
+    {
+        try {
+            $response = $this->browser->post(
+                self::AUTH_URL . "?Subscription-Key=" . urlencode($this->azureKey)
+            );
+        }
+        catch (\Exception $previous) {
+            throw new RequestFailedException(sprintf(
+                'Request failed: %s',
+                $previous->getMessage()
+            ), null, $previous);
+        }
+
+        if (!$response->isSuccessful()) {
+            throw new RequestFailedException(sprintf(
+                'Call to Auth server failed, %d: %s',
+                $response->getStatusCode(),
+                $response->getReasonPhrase()
+            ));
+        }
+
+        /* @var $response \Buzz\Message\Response */
+        return $response->getContent();
+    }
+}

--- a/tests/MatthiasNoback/MicrosoftOAuth/AzureTokenProviderTest.php
+++ b/tests/MatthiasNoback/MicrosoftOAuth/AzureTokenProviderTest.php
@@ -21,7 +21,7 @@ class AzuresTokenProviderTest extends \PHPUnit_Framework_TestCase
             ->method('post')
             ->with(
                 'https://api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=' . $azureKey,
-                ['Content-Length' => 0]
+                array('Content-Length' => 0)
             )
             ->will($this->returnValue($response));
         $accessTokenProvider = new AzureTokenProvider($browser, $azureKey);

--- a/tests/MatthiasNoback/MicrosoftOAuth/AzureTokenProviderTest.php
+++ b/tests/MatthiasNoback/MicrosoftOAuth/AzureTokenProviderTest.php
@@ -20,7 +20,8 @@ class AzuresTokenProviderTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('post')
             ->with(
-                'https://api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=' . $azureKey
+                'https://api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=' . $azureKey,
+                ['Content-Length' => 0]
             )
             ->will($this->returnValue($response));
         $accessTokenProvider = new AzureTokenProvider($browser, $azureKey);

--- a/tests/MatthiasNoback/MicrosoftOAuth/AzureTokenProviderTest.php
+++ b/tests/MatthiasNoback/MicrosoftOAuth/AzureTokenProviderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace MatthiasNoback\Tests\MicrosoftOAuth;
+
+use MatthiasNoback\MicrosoftOAuth\AzureTokenProvider;
+
+class AzuresTokenProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTokenWithoutCache()
+    {
+        $azureKey = 'azureKey';
+        $accessToken = 'accessToken';
+        $scope = 'theScope';
+        $grantType = 'theGrantType';
+
+        $response = $this->createMockResponse($accessToken);
+
+        $browser = $this->createMockBrowser();
+        $browser
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                'https://api.cognitive.microsoft.com/sts/v1.0/issueToken?Subscription-Key=' . $azureKey
+            )
+            ->will($this->returnValue($response));
+        $accessTokenProvider = new AzureTokenProvider($browser, $azureKey);
+
+        $actualAccessToken = $accessTokenProvider->getAccessToken($scope, $grantType);
+
+        $this->assertSame($accessToken, $actualAccessToken);
+    }
+
+    public function testGetTokenWithCacheMiss()
+    {
+        $scope = 'theScope';
+        $grantType = 'theGrantType';
+
+        $accessToken = 'accessToken';
+
+        // the cache does not contain an access token yet
+        $accessTokenCache = $this->createMockAccessTokenCache();
+        $accessTokenCache
+            ->expects($this->once())
+            ->method('has')
+            ->with($scope, $grantType)
+            ->will($this->returnValue(false));
+
+        // the browser will used to fetch a fresh access token
+        $response = $this->createMockResponse($accessToken);
+        $browser = $this->createMockBrowser();
+        $browser
+            ->expects($this->once())
+            ->method('post')
+            ->will($this->returnValue($response));
+
+        // finally, the access token should be stored in the cache
+        $accessTokenCache
+            ->expects($this->once())
+            ->method('set')
+            ->with($scope, $grantType, $accessToken);
+
+
+        $accessTokenProvider = new AzureTokenProvider($browser, 'azureKey');
+        $accessTokenProvider->setCache($accessTokenCache);
+
+        $actualAccessToken = $accessTokenProvider->getAccessToken($scope, $grantType);
+
+        $this->assertSame($accessToken, $actualAccessToken);
+    }
+
+    public function testGetTokenWithCacheHit()
+    {
+        $scope = 'theScope';
+        $grantType = 'theGrantType';
+
+        $accessToken = 'accessToken';
+
+        // the cache already contains an access token
+        $accessTokenCache = $this->createMockAccessTokenCache();
+        $accessTokenCache
+            ->expects($this->once())
+            ->method('has')
+            ->with($scope, $grantType)
+            ->will($this->returnValue(true));
+
+        // the browser should not be used
+        $browser = $this->createMockBrowser();
+        $browser
+            ->expects($this->never())
+            ->method('post');
+
+        // the access token will be retrieved from the cache
+        $accessTokenCache
+            ->expects($this->once())
+            ->method('get')
+            ->with($scope, $grantType)
+            ->will($this->returnValue($accessToken));
+
+        $accessTokenProvider = new AzureTokenProvider($browser, 'azureKey');
+        $accessTokenProvider->setCache($accessTokenCache);
+
+        $accessTokenProvider->getAccessToken($scope, $grantType);
+    }
+
+    private function createMockBrowser()
+    {
+        return $this
+            ->getMockBuilder('Buzz\\Browser')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function createMockResponse($content)
+    {
+        $response = $this->getMock('Buzz\Message\Response');
+        $response
+            ->expects($this->any())
+            ->method('getContent')
+            ->will($this->returnValue($content));
+
+        $response
+            ->expects($this->any())
+            ->method('isSuccessful')
+            ->will($this->returnValue(true));
+
+        return $response;
+    }
+
+    private function createMockAccessTokenCache()
+    {
+        return $this->getMock('MatthiasNoback\MicrosoftOAuth\AccessTokenCacheInterface');
+    }
+}

--- a/tests/MatthiasNoback/MicrosoftTranslator/MicrosoftAzureTranslatorFunctionalTest.php
+++ b/tests/MatthiasNoback/MicrosoftTranslator/MicrosoftAzureTranslatorFunctionalTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace MatthiasNoback\Tests\MicrosoftTranslator;
+
+use Buzz\Browser;
+use Buzz\Client\Curl;
+use Doctrine\Common\Cache\ArrayCache;
+use MatthiasNoback\Buzz\Client\CachedClient;
+use MatthiasNoback\MicrosoftOAuth\AccessTokenCache;
+use MatthiasNoback\MicrosoftOAuth\AzureTokenProvider;
+use MatthiasNoback\MicrosoftTranslator\ApiCall\Response\TranslationMatch;
+use MatthiasNoback\MicrosoftTranslator\ApiCall\Translate;
+use MatthiasNoback\MicrosoftTranslator\MicrosoftTranslator;
+
+class MicrosoftAzureTranslatorFunctionalTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MicrosoftTranslator
+     */
+    private $translator;
+
+    /**
+     * @var Browser
+     */
+    private $browser;
+
+    protected function setUp()
+    {
+        $client = new Curl();
+        $client->setTimeout(30);
+        $this->browser = new Browser($client);
+
+        $azureKey = $this->getEnvironmentVariable('MICROSOFT_AZURE_KEY');
+        $cache = new ArrayCache();
+        $accessTokenCache = new AccessTokenCache($cache);
+        $accessTokenProvider = new AzureTokenProvider($this->browser, $azureKey);
+        $accessTokenProvider->setCache($accessTokenCache);
+
+        $this->translator = new MicrosoftTranslator($this->browser, $accessTokenProvider);
+    }
+
+    public function testTranslate()
+    {
+        $translated = $this->translator->translate('This is a test', 'nl', 'en');
+
+        $this->assertSame('Dit is een test', $translated);
+
+        $translated = $this->translator->translate(
+            '<p class="name">This is a test</p>',
+            'nl',
+            'en',
+            null,
+            Translate::CONTENT_TYPE_HTML
+        );
+
+        $this->assertSame('<p class="name">Dit is een test</p>', $translated);
+
+        $translated = $this->translator->translate(
+            '<p>This is a test.<span class="notranslate">This is a test.</span></p>',
+            'nl',
+            'en',
+            null,
+            Translate::CONTENT_TYPE_HTML
+        );
+
+        $this->assertSame('<p>Dit is een test.<span class="notranslate">This is a test.</span></p>', $translated);
+    }
+
+    public function testTranslateArray()
+    {
+        $translatedTexts = $this->translator->translateArray(array(
+            'This is a test',
+            'My name is Matthias',
+            'You are naïve!',
+        ), 'nl', 'en');
+
+        $this->assertSame(array(
+            'Dit is een test',
+            'Mijn naam is Matthias',
+            'Je bent naïef!',
+        ), $translatedTexts);
+    }
+
+    public function testGetTranslations()
+    {
+        $translated = $this->translator->getTranslations('This is a test', 'nl', 'en', 1);
+
+        $this->assertEquals(array(new TranslationMatch('Dit is een test', 100)), $translated);
+    }
+
+    public function testDetect()
+    {
+        $text = 'This is a test';
+
+        $detectedLanguage = $this->translator->detect($text);
+
+        $this->assertSame('en', $detectedLanguage);
+    }
+
+    public function testDetectArray()
+    {
+        $texts = array(
+            'This is a test',
+            'Dit is een test',
+        );
+
+        $detectedLanguages = $this->translator->detectArray($texts);
+
+        $this->assertSame(array('en', 'nl'), $detectedLanguages);
+    }
+
+    public function testBreakSentences()
+    {
+        $text = 'This is the first sentence. This is the second sentence. This is the last sentence.';
+
+        $sentences = $this->translator->breakSentences($text, 'en');
+
+        $this->assertSame(array(
+            'This is the first sentence. ',
+            'This is the second sentence. ',
+            'This is the last sentence.',
+        ), $sentences);
+    }
+
+    public function testSpeak()
+    {
+        $saveAudioTo = $this->getEnvironmentVariable('MICROSOFT_TRANSLATOR_SAVE_AUDIO_TO');
+        if (!is_writable($saveAudioTo)) {
+            $this->markTestSkipped(sprintf('Can not save audio file to "%s"', $saveAudioTo));
+        }
+
+        $text = 'My name is Matthias';
+
+        $spoken = $this->translator->speak($text, 'en', 'audio/mp3', 'MaxQuality');
+
+        file_put_contents($saveAudioTo.'/speak.mp3', $spoken);
+    }
+
+    public function testGetLanguagesForSpeak()
+    {
+        $languageCodes = $this->translator->getLanguagesForSpeak();
+        $this->assertInternalType('array', $languageCodes);
+        $this->assertTrue(count($languageCodes) > 30);
+    }
+
+    public function testGetLanguagesForTranslate()
+    {
+        $languageCodes = $this->translator->getLanguagesForTranslate();
+        $this->assertInternalType('array', $languageCodes);
+        $this->assertTrue(count($languageCodes) > 30);
+
+        return $languageCodes;
+    }
+
+    public function testGetLanguageNames()
+    {
+        $languageCodes = $this->translator->getLanguagesForSpeak();
+
+        $languageNames = $this->translator->getLanguageNames($languageCodes, 'nl');
+
+        foreach ($languageCodes as $languageCode) {
+            $this->assertArrayHasKey($languageCode, $languageNames);
+        }
+    }
+
+    public function testCachedBrowserClient()
+    {
+        $currentClient = $this->browser->getClient();
+
+        $arrayCache = new ArrayCache();
+        $cachedClient = new CachedClient($currentClient, $arrayCache);
+
+        $this->browser->setClient($cachedClient);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->translator->translate('This is a test', 'nl');
+        }
+
+        $this->assertLessThanOrEqual(2, $cachedClient->getMisses()); // at most one for the access token, one for the translation
+        $this->assertSame(2, $cachedClient->getHits());
+
+        $this->browser->setClient($currentClient);
+    }
+
+    private function getEnvironmentVariable($name)
+    {
+        if (getenv($name) === false) {
+            $this->markTestSkipped(sprintf('Environment variable "%s" is missing', $name));
+        }
+
+        return getenv($name);
+    }
+}


### PR DESCRIPTION
As Microsoft DataMarket services are being deprecated, an upgrade to Azure keys is needed.
This pull request provides a new Azure Token Provider that easies this transition.