### PR TITLE
Use Buzz ^0.16 because of BC breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "doctrine/common": "~2.2",
-        "kriswallsmith/buzz": "0.*"
+        "kriswallsmith/buzz": "^0.16.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3"


### PR DESCRIPTION
Buzz 0.17 introduced many BC breaks. We should force v 0.16.1 until all our code is updated to support the new version.
https://github.com/kriswallsmith/Buzz/blob/master/CHANGELOG.md#0170