### PR TITLE
Fix Deprecation notice

### DIFF
--- a/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
+++ b/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
@@ -17,7 +17,7 @@ abstract class AbstractMicrosoftTranslatorApiCall implements ApiCallInterface
         $url = self::HTTP_API_URL.$this->getApiMethodName();
         if (null !== $queryParameters = $this->getQueryParameters()) {
             $queryParameters['api-version'] = '3.0';
-            $url .= '?'.http_build_query($queryParameters, null, '&');
+            $url .= '?'.http_build_query($queryParameters, '', '&');
         }
         return $url;
     }


### PR DESCRIPTION
This fixes the notice:
Deprecated Functionality: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated The empty string '' is the default parameter so it is the correct thing to pass here.