### PR TITLE
Character limit increase

### DIFF
--- a/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
+++ b/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
@@ -17,7 +17,7 @@ abstract class AbstractMicrosoftTranslatorApiCall implements ApiCallInterface
         $url = self::HTTP_API_URL.$this->getApiMethodName();
         if (null !== $queryParameters = $this->getQueryParameters()) {
             $queryParameters['api-version'] = '3.0';
-            $url .= '?'.http_build_query($queryParameters, null, '&');
+            $url .= '?'.http_build_query($queryParameters, '', '&');
         }
         return $url;
     }

--- a/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
+++ b/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
@@ -8,7 +8,7 @@ abstract class AbstractMicrosoftTranslatorApiCall implements ApiCallInterface
 {
     const HTTP_API_URL = 'https://api.cognitive.microsofttranslator.com/';
 
-    const MAXIMUM_LENGTH_OF_TEXT = 5000;
+    const MAXIMUM_LENGTH_OF_TEXT = 50000;
 
     abstract public function getApiMethodName();
 

--- a/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
+++ b/src/MatthiasNoback/MicrosoftTranslator/ApiCall/AbstractMicrosoftTranslatorApiCall.php
@@ -8,7 +8,7 @@ abstract class AbstractMicrosoftTranslatorApiCall implements ApiCallInterface
 {
     const HTTP_API_URL = 'https://api.cognitive.microsofttranslator.com/';
 
-    const MAXIMUM_LENGTH_OF_TEXT = 10000;
+    const MAXIMUM_LENGTH_OF_TEXT = 5000;
 
     abstract public function getApiMethodName();
 


### PR DESCRIPTION
Per https://learn.microsoft.com/en-us/azure/ai-services/translator/service-limits the character limit is 50,000 and it seems to be true. Not sure if it represents an increase from the past but.

Also fixes Deprecation notice again.